### PR TITLE
node's version update to v12.13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN set -ex \
   done
 
 ENV NPM_CONFIG_LOGLEVEL info
-ENV NODE_VERSION 8.12.0
+ENV NODE_VERSION 12.13.0
 
 RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.xz" \
   && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \


### PR DESCRIPTION
# Node.jsのバージョンアップ

古くなっているビルド用Node.jsのバージョンを最新のLTSバージョンに変更する

- v8.12.0 => v12.13.0